### PR TITLE
fix(android): parse error with code instead of message after pigeon u…

### DIFF
--- a/flutter_lyra/CHANGELOG.md
+++ b/flutter_lyra/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+ - **FIX**: Android error parsing.
+
 # 0.1.2
 
 - Add cancelProcess method

--- a/flutter_lyra/pubspec.yaml
+++ b/flutter_lyra/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_lyra
 description: This package allows you to use the methods from the lyra android and ios native sdks in Flutter
-version: 0.1.2
+version: 0.1.3
 homepage: https://github.com/bamlab/Flutter-Lyra
 repository: https://github.com/bamlab/Flutter-Lyra
 
@@ -20,7 +20,7 @@ dependencies:
   equatable: ^2.0.5
   flutter:
     sdk: flutter
-  flutter_lyra_android: ^0.1.2
+  flutter_lyra_android: ^0.1.2+1
   flutter_lyra_ios: ^0.1.2
   flutter_lyra_platform_interface: ^0.1.2
 

--- a/flutter_lyra_android/CHANGELOG.md
+++ b/flutter_lyra_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2+1
+
+ - **FIX**: Android error parsing.
+
 # 0.1.2
 
 - Add cancelProcess method

--- a/flutter_lyra_android/lib/flutter_lyra_android.dart
+++ b/flutter_lyra_android/lib/flutter_lyra_android.dart
@@ -7,11 +7,9 @@ class FlutterLyraAndroid extends FlutterLyraPlatform {
   @override
   Never parseError(Object error, StackTrace stackTrace) {
     if (error is PlatformException) {
-      final errorMessage = error.message;
-      if (errorMessage != null) {
-        if (errorMessage.contains(errorCodesInterface.paymentCancelledByUser)) {
-          throw PaymentCancelledByUserExceptionInterface();
-        }
+      final errorCode = error.code;
+      if (errorCode.contains(errorCodesInterface.paymentCancelledByUser)) {
+        throw PaymentCancelledByUserExceptionInterface();
       }
     }
     return Error.throwWithStackTrace(error, stackTrace);

--- a/flutter_lyra_android/pubspec.yaml
+++ b/flutter_lyra_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_lyra_android
 description: Android implementation of the flutter_lyra plugin
-version: 0.1.2
+version: 0.1.2+1
 homepage: https://github.com/bamlab/Flutter-Lyra
 repository: https://github.com/bamlab/Flutter-Lyra
 

--- a/flutter_lyra_android/test/flutter_lyra_android_test.dart
+++ b/flutter_lyra_android/test/flutter_lyra_android_test.dart
@@ -73,8 +73,8 @@ void main() {
 
       test('$PaymentCancelledByUserExceptionInterface', () {
         final exception = PlatformException(
-          code: 'code',
-          message: errorCodesInterface.paymentCancelledByUser,
+          code: errorCodesInterface.paymentCancelledByUser,
+          message: 'message',
         );
 
         Object? error;

--- a/flutter_lyra_android/test/flutter_lyra_android_test.dart
+++ b/flutter_lyra_android/test/flutter_lyra_android_test.dart
@@ -73,8 +73,9 @@ void main() {
 
       test('$PaymentCancelledByUserExceptionInterface', () {
         final exception = PlatformException(
-          code: errorCodesInterface.paymentCancelledByUser,
-          message: 'message',
+          code:
+              '''tech.bam.flutter_lyra.android.FlutterError: payment_cancelled_by_user_code - Payment cancelled''',
+          message: 'FlutterError',
         );
 
         Object? error;


### PR DESCRIPTION
## Description

Fix the error parsing on Android. The update of pigeon to v7 introduced a shift between error `code` and `message` (on Android only).

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
