### PR TITLE
chore(android): bump Android Lyra SDK to 1.8.0 to enable Google Pay

### DIFF
--- a/flutter_lyra_android/android/build.gradle
+++ b/flutter_lyra_android/android/build.gradle
@@ -48,5 +48,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation 'com.lyra:sdk:1.5.7'
+    implementation 'com.lyra:sdk:1.6.9'
 }

--- a/flutter_lyra_android/android/build.gradle
+++ b/flutter_lyra_android/android/build.gradle
@@ -48,5 +48,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation 'com.lyra:sdk:1.6.9'
+    implementation 'com.lyra:sdk:1.8.0'
 }


### PR DESCRIPTION
I use Flutter and it looks like there is a conflict with the Sentry embedded in the native SDKs and the sentry_flutter Flutter package. I had this error.

<img width="908" alt="error" src="https://github.com/user-attachments/assets/49853e92-0c0c-4742-a299-9c6def8cb1a4">

## Description

I saw that the Android native sdk version used in the lyra_flutter package was 1.5.7, which is not the last one. The last Android SDK version is 1.6.9 so i changed it and it works !

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
